### PR TITLE
manage int64 long value on save and reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ resourceSet.getURIConverter().getURIMap().put(
 Resource resource = resourceSet.createResource(URI.createURI("http://resources/model1"));
 ```
 
+Override the name of the field to avoid problem with the reserved name of Bson. And set the uri handler, to avoid problem with external resources.
+
+```java
+	HashMap<String, Object> DEFAULT_OPTIONS = new HashMap<String, Object>();
+	DEFAULT_OPTIONS.put(EMFJs.OPTION_URI_HANDLER, new IdentityURIHandler());
+	DEFAULT_OPTIONS.put(EMFJs.OPTION_REF_FIELD, "_ref");
+	resourceSet.getLoadOptions().putAll(DEFAULT_OPTIONS);
+```
+
 Saving documents
 
 ```java

--- a/src/main/java/org/emfjson/mongo/MongoHandler.java
+++ b/src/main/java/org/emfjson/mongo/MongoHandler.java
@@ -17,6 +17,11 @@ import java.util.Map;
 public class MongoHandler extends URIHandlerImpl {
 
 	private final MongoClient client;
+	public static final String ID_FIELD = "_id";
+	public static final String TYPE_FIELD = "_type";
+	public static final String CONTENTS_FIELD = "contents";
+	
+	
 
 	public MongoHandler(MongoClient client) {
 		this.client = client;
@@ -41,8 +46,8 @@ public class MongoHandler extends URIHandlerImpl {
 	public void delete(URI uri, Map<?, ?> options) throws IOException {
 		final MongoCollection<Document> collection = getCollection(uri);
 		final Map<String, Object> filter = new HashMap<>();
-		filter.put("_id", uri.segment(2));
-		filter.put("type", "resource");
+		filter.put(ID_FIELD, uri.segment(2));
+		filter.put(TYPE_FIELD, "resource");
 
 		collection.findOneAndDelete(new Document(filter));
 	}
@@ -51,8 +56,8 @@ public class MongoHandler extends URIHandlerImpl {
 	public boolean exists(URI uri, Map<?, ?> options) {
 		final MongoCollection<Document> collection = getCollection(uri);
 		final Map<String, Object> filter = new HashMap<>();
-		filter.put("_id", uri.segment(2));
-		filter.put("type", "resource");
+		filter.put(ID_FIELD, uri.segment(2));
+		filter.put(TYPE_FIELD, "resource");
 
 		return collection.find(new Document(filter)).limit(1).first() != null;
 	}

--- a/src/main/java/org/emfjson/mongo/bson/codecs/JsonWriter.java
+++ b/src/main/java/org/emfjson/mongo/bson/codecs/JsonWriter.java
@@ -1,0 +1,367 @@
+package org.emfjson.mongo.bson.codecs;
+
+import static javax.xml.bind.DatatypeConverter.printBase64Binary;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import org.bson.BSONException;
+import org.bson.BsonBinary;
+import org.bson.BsonContextType;
+import org.bson.BsonDbPointer;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonTimestamp;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.bson.types.ObjectId;
+
+public class JsonWriter extends org.bson.json.JsonWriter {
+
+	private final JsonWriterSettings settings;
+
+	public JsonWriter(Writer writer) {
+		this(writer, new JsonWriterSettings());
+	}
+
+	public JsonWriter(final Writer writer, final JsonWriterSettings settings) {
+		super(writer, settings);
+		this.settings = settings;
+		if(settings.getOutputMode().equals(JsonMode.SHELL))
+			throw new IllegalArgumentException("JsonMode must not be SHELL");
+		setContext(new Context(null, BsonContextType.TOP_LEVEL, ""));
+	}
+
+	@Override
+	protected void doWriteStartDocument() {
+		try {
+			if (getState() == State.VALUE || getState() == State.SCOPE_DOCUMENT) {
+				writeNameHelper(getName());
+			}
+			getWriter().write("{");
+
+			BsonContextType contextType = (getState() == State.SCOPE_DOCUMENT) ? BsonContextType.SCOPE_DOCUMENT
+					: BsonContextType.DOCUMENT;
+			setContext(new Context(getContext(), contextType, settings.getIndentCharacters()));
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	protected void doWriteStartArray() {
+		try {
+			writeNameHelper(getName());
+			getWriter().write("[");
+			setContext(new Context(getContext(), BsonContextType.ARRAY, settings.getIndentCharacters()));
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	protected void doWriteBinaryData(final BsonBinary binary) {
+		writeStartDocument();
+		writeString("$binary", printBase64Binary(binary.getData()));
+		writeString("$type", Integer.toHexString(binary.getType() & 0xFF));
+		writeEndDocument();
+	}
+
+	@Override
+	public void doWriteBoolean(final boolean value) {
+		try {
+			writeNameHelper(getName());
+			getWriter().write(value ? "true" : "false");
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	protected void doWriteDateTime(final long value) {
+		try {
+			writeNameHelper(getName());
+			getWriter().write(Long.toString(value));
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	protected void doWriteDBPointer(final BsonDbPointer value) {
+		writeStartDocument();
+		writeString("$ref", value.getNamespace());
+		writeObjectId("$id", value.getId());
+		writeEndDocument();
+	}
+
+	@Override
+	protected void doWriteDouble(final double value) {
+		try {
+			writeNameHelper(getName());
+			getWriter().write(Double.toString(value));
+			setState(getNextState());
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	protected void doWriteInt32(final int value) {
+		try {
+			writeNameHelper(getName());
+			getWriter().write(Integer.toString(value));
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	protected void doWriteInt64(final long value) {
+		try {
+			writeNameHelper(getName());
+			getWriter().write(Long.toString(value));
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	protected void doWriteJavaScript(final String code) {
+		writeStartDocument();
+		writeString("$code", code);
+		writeEndDocument();
+	}
+
+	@Override
+	protected void doWriteJavaScriptWithScope(final String code) {
+		writeStartDocument();
+		writeString("$code", code);
+		writeName("$scope");
+	}
+
+	@Override
+	protected void doWriteMaxKey() {
+		writeStartDocument();
+		writeInt32("$maxKey", 1);
+		writeEndDocument();
+	}
+
+	@Override
+	protected void doWriteMinKey() {
+		writeStartDocument();
+		writeInt32("$minKey", 1);
+		writeEndDocument();
+	}
+
+	@Override
+	public void doWriteNull() {
+		try {
+			writeNameHelper(getName());
+			getWriter().write("null");
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	public void doWriteObjectId(final ObjectId objectId) {
+		writeStartDocument();
+		writeString("$oid", objectId.toString());
+		writeEndDocument();
+	}
+
+	@Override
+	public void doWriteRegularExpression(final BsonRegularExpression regularExpression) {
+		try {
+			writeNameHelper(getName());
+			getWriter().write("/");
+			String escaped = (regularExpression.getPattern().equals("")) ? "(?:)"
+					: regularExpression.getPattern().replace("/", "\\/");
+			getWriter().write(escaped);
+			getWriter().write("/");
+			getWriter().write(regularExpression.getOptions());
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	public void doWriteString(final String value) {
+		try {
+			writeNameHelper(getName());
+			writeStringHelper(value);
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	@Override
+	public void doWriteSymbol(final String value) {
+		writeStartDocument();
+		writeString("$symbol", value);
+		writeEndDocument();
+	}
+
+	@Override
+	public void doWriteTimestamp(final BsonTimestamp value) {
+			writeStartDocument();
+			writeStartDocument("$timestamp");
+			writeInt32("t", value.getTime());
+			writeInt32("i", value.getInc());
+			writeEndDocument();
+			writeEndDocument();
+	}
+
+	@Override
+	public void doWriteUndefined() {
+		try {
+			writeNameHelper(getName());
+			getWriter().write("undefined");
+		} catch (IOException e) {
+			throwBSONException(e);
+		}
+	}
+
+	private void throwBSONException(final IOException e) {
+		throw new BSONException("Wrapping IOException", e);
+	}
+
+	private void writeNameHelper(final String name) throws IOException {
+		switch (getContext().getContextType()) {
+		case ARRAY:
+			// don't write Array element names in JSON
+			if (getContext().hasElements()) {
+				getWriter().write(", ");
+			}
+			break;
+		case DOCUMENT:
+		case SCOPE_DOCUMENT:
+			if (getContext().hasElements()) {
+				getWriter().write(",");
+			}
+			if (settings.isIndent()) {
+				getWriter().write(settings.getNewLineCharacters());
+				getWriter().write(getContext().getIndentation());
+			} else {
+				getWriter().write(" ");
+			}
+			writeStringHelper(name);
+			getWriter().write(" : ");
+			break;
+		case TOP_LEVEL:
+			break;
+		default:
+			throw new BSONException("Invalid contextType.");
+		}
+
+		getContext().hasElements(true);
+	}
+
+	private void writeStringHelper(final String str) throws IOException {
+		getWriter().write('"');
+		for (final char c : str.toCharArray()) {
+			switch (c) {
+			case '"':
+				getWriter().write("\\\"");
+				break;
+			case '\\':
+				getWriter().write("\\\\");
+				break;
+			case '\b':
+				getWriter().write("\\b");
+				break;
+			case '\f':
+				getWriter().write("\\f");
+				break;
+			case '\n':
+				getWriter().write("\\n");
+				break;
+			case '\r':
+				getWriter().write("\\r");
+				break;
+			case '\t':
+				getWriter().write("\\t");
+				break;
+			default:
+				switch (Character.getType(c)) {
+				case Character.UPPERCASE_LETTER:
+				case Character.LOWERCASE_LETTER:
+				case Character.TITLECASE_LETTER:
+				case Character.OTHER_LETTER:
+				case Character.DECIMAL_DIGIT_NUMBER:
+				case Character.LETTER_NUMBER:
+				case Character.OTHER_NUMBER:
+				case Character.SPACE_SEPARATOR:
+				case Character.CONNECTOR_PUNCTUATION:
+				case Character.DASH_PUNCTUATION:
+				case Character.START_PUNCTUATION:
+				case Character.END_PUNCTUATION:
+				case Character.INITIAL_QUOTE_PUNCTUATION:
+				case Character.FINAL_QUOTE_PUNCTUATION:
+				case Character.OTHER_PUNCTUATION:
+				case Character.MATH_SYMBOL:
+				case Character.CURRENCY_SYMBOL:
+				case Character.MODIFIER_SYMBOL:
+				case Character.OTHER_SYMBOL:
+					getWriter().write(c);
+					break;
+				default:
+					getWriter().write("\\u");
+					getWriter().write(Integer.toHexString((c & 0xf000) >> 12));
+					getWriter().write(Integer.toHexString((c & 0x0f00) >> 8));
+					getWriter().write(Integer.toHexString((c & 0x00f0) >> 4));
+					getWriter().write(Integer.toHexString(c & 0x000f));
+					break;
+				}
+				break;
+			}
+		}
+		getWriter().write('"');
+	}
+
+	@Override
+	protected Context getContext() {
+		return (Context) super.getContext();
+	}
+
+	/**
+	 * The context for the writer, inheriting all the values from
+	 * {@link org.bson.AbstractBsonWriter.Context}, and additionally providing
+	 * settings for the indentation level and whether there are any child
+	 * elements at this level.
+	 */
+	public class Context extends org.bson.json.JsonWriter.Context {
+		private final String indentation;
+
+		public String getIndentation() {
+			return indentation;
+		}
+
+		private boolean hasElements;
+
+		public boolean hasElements() {
+			return hasElements;
+		}
+
+		public void hasElements(boolean hasElements) {
+			this.hasElements = hasElements;
+		}
+
+		/**
+		 * Creates a new context.
+		 *
+		 * @param parentContext
+		 *            the parent context that can be used for going back up to
+		 *            the parent level
+		 * @param contextType
+		 *            the type of this context
+		 * @param indentChars
+		 *            the String to use for indentation at this level.
+		 */
+		public Context(final Context parentContext, final BsonContextType contextType, final String indentChars) {
+			super(parentContext, contextType, indentChars);
+			this.indentation = (parentContext == null) ? indentChars : parentContext.indentation + indentChars;
+		}
+
+	}
+}

--- a/src/main/java/org/emfjson/mongo/streams/MongoInputStream.java
+++ b/src/main/java/org/emfjson/mongo/streams/MongoInputStream.java
@@ -37,14 +37,14 @@ public class MongoInputStream extends InputStream implements Loadable {
 		}
 
 		final String id = uri.segment(2);
-		final Document filter = new Document("_id", id);
+		final Document filter = new Document(MongoHandler.ID_FIELD, id);
 		final Document document = collection
 				.find(filter)
 				.limit(1)
 				.first();
 
 		if (document == null) {
-			throw new IOException("Cannot find document with _id " + id);
+			throw new IOException("Cannot find document with " + MongoHandler.ID_FIELD + " " + id);
 		}
 
 		readJson(resource, document.toJson());
@@ -58,7 +58,7 @@ public class MongoInputStream extends InputStream implements Loadable {
 		mapper.registerModule(module);
 
 		final JsonNode rootNode = mapper.readTree(data);
-		final JsonNode contents = rootNode.has("contents") ? rootNode.get("contents") : null;
+		final JsonNode contents = rootNode.has(MongoHandler.CONTENTS_FIELD) ? rootNode.get(MongoHandler.CONTENTS_FIELD) : null;
 
 		if (contents != null) {
 			mapper.reader()

--- a/src/main/java/org/emfjson/mongo/streams/MongoInputStream.java
+++ b/src/main/java/org/emfjson/mongo/streams/MongoInputStream.java
@@ -1,19 +1,24 @@
 package org.emfjson.mongo.streams;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.client.MongoCollection;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.Map;
+
 import org.bson.Document;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.EncoderContext;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.URIConverter.Loadable;
 import org.emfjson.jackson.JacksonOptions;
 import org.emfjson.jackson.module.EMFModule;
 import org.emfjson.mongo.MongoHandler;
+import org.emfjson.mongo.bson.codecs.JsonWriter;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.MongoCollection;
 
 public class MongoInputStream extends InputStream implements Loadable {
 
@@ -47,7 +52,9 @@ public class MongoInputStream extends InputStream implements Loadable {
 			throw new IOException("Cannot find document with " + MongoHandler.ID_FIELD + " " + id);
 		}
 
-		readJson(resource, document.toJson());
+		JsonWriter writer = new JsonWriter(new StringWriter());
+		new DocumentCodec().encode(writer, document, EncoderContext.builder().isEncodingCollectibleDocument(true).build());
+		readJson(resource, writer.getWriter().toString());
 	}
 
 	private void readJson(Resource resource, String data) throws IOException {

--- a/src/main/java/org/emfjson/mongo/streams/MongoOutputStream.java
+++ b/src/main/java/org/emfjson/mongo/streams/MongoOutputStream.java
@@ -42,7 +42,7 @@ public class MongoOutputStream extends ByteArrayOutputStream implements Saveable
 			throw new IOException("Error during saving");
 		}
 
-		final Document filter = new Document("_id", uri.segment(2));
+		final Document filter = new Document(MongoHandler.ID_FIELD, uri.segment(2));
 		if (collection.find(filter).limit(1).first() == null) {
 			collection.insertOne(Document.parse(data));
 		} else {
@@ -59,9 +59,9 @@ public class MongoOutputStream extends ByteArrayOutputStream implements Saveable
 		final ObjectNode resourceNode = mapper.createObjectNode();
 		final String id = uri.segment(2);
 
-		resourceNode.put("_id", id);
-		resourceNode.put("_type", "resource");
-		resourceNode.set("contents", contents);
+		resourceNode.put(MongoHandler.ID_FIELD, id);
+		resourceNode.put(MongoHandler.TYPE_FIELD, "resource");
+		resourceNode.set(MongoHandler.CONTENTS_FIELD, contents);
 
 		return mapper.writeValueAsString(resourceNode);
 	}

--- a/src/test/java/org/emfjson/mongo/tests/MongoHandlerSaveAndLoadTest.java
+++ b/src/test/java/org/emfjson/mongo/tests/MongoHandlerSaveAndLoadTest.java
@@ -1,0 +1,82 @@
+package org.emfjson.mongo.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.bson.Document;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.emfjson.jackson.resource.JsonResourceFactory;
+import org.emfjson.model.ModelPackage;
+import org.emfjson.model.TestA;
+import org.emfjson.mongo.MongoHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+
+public class MongoHandlerSaveAndLoadTest {
+
+	private ResourceSet resourceSet;
+	private MongoClient client;
+	private MongoHandler handler;
+	private URI testURI = URI.createURI("mongodb://localhost:27017/emfjson-test/models/model1");
+
+	@Before
+	public void setUp() {
+		client = new MongoClient();
+		handler = new MongoHandler(client);
+		resourceSet = new ResourceSetImpl();
+
+		resourceSet.getPackageRegistry().put(EcorePackage.eNS_URI, EcorePackage.eINSTANCE);
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("*", new JsonResourceFactory());
+		resourceSet.getURIConverter().getURIHandlers().add(0, handler);
+	}
+
+	@After
+	public void tearDown() {
+		client.getDatabase("emfjson-test").drop();
+	}
+
+	@Test
+	public void testSaveThenLoadNode() throws IOException {
+		MongoCollection<Document> models = handler.getCollection(testURI);
+		
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode content_model1 = mapper.createObjectNode()
+				.put("_id", "model1")
+				.put("_type", "resource")
+				.set("contents", mapper.createObjectNode()
+						.put("eClass", EcoreUtil.getURI(ModelPackage.Literals.TEST_A).toString())
+						.put("stringValue", "testStringValue")
+						.put("intValue", 1234)
+						.put("booleanValue", true)
+						.put("longValue", 12345678900L));
+		
+		
+		models.insertOne(Document.parse(mapper.writeValueAsString(content_model1)));
+		
+		Resource resource = resourceSet.createResource(testURI);
+		resource.load(null);
+
+		assertEquals(1, resource.getContents().size());
+		assertEquals(ModelPackage.Literals.TEST_A, resource.getContents().get(0).eClass());
+
+		TestA ta = (TestA) resource.getContents().get(0);
+
+		assertEquals("testStringValue", ta.getStringValue());
+		assertEquals(1234, ta.getIntValue().intValue());
+		assertEquals(true, ta.getBooleanValue().booleanValue());
+		assertEquals(12345678900L, ta.getLongValue().longValue());
+	}
+
+}

--- a/src/test/resources/model.xcore
+++ b/src/test/resources/model.xcore
@@ -15,6 +15,8 @@ class TestA {
 	Boolean[*] multiBooleanValues
 	TestKind kind
 	TestKind[*] multiKinds
+	Long longValue
+	Long[*] multiLongValues
 
 	refers TestB oneB
 	refers TestB[*] manyBs


### PR DESCRIPTION
Due to https://jira.mongodb.org/browse/JAVA-1280
I create a PR on the mongo driver but as we wait for this, we need to manager the BSON specific value (date and int64 long value).

I have not yet tested with date. because i don't need it.
